### PR TITLE
fix: using valid assertion method

### DIFF
--- a/test/unit/char-analyzer.js
+++ b/test/unit/char-analyzer.js
@@ -5,47 +5,46 @@ import { CharAnalyzer } from '../../src/char-analyzer.js';
 describe('Unit: CharAnalyzer', () => {
     describe('Unit: isWhiteSpace', () => {
         it('check real white space', () => {
-            assert(CharAnalyzer.isWhiteSpace(' '));
-            assert(CharAnalyzer.isWhiteSpace('\n'));
-            assert(CharAnalyzer.isWhiteSpace(`
-`));
+            assert.isTrue(CharAnalyzer.isWhiteSpace(' '));
+            assert.isTrue(CharAnalyzer.isWhiteSpace('\n'));
+            assert.isFalse(CharAnalyzer.isWhiteSpace(''));
         });
         it('check fake white space', () => {
-            assert(!CharAnalyzer.isWhiteSpace('a'));
-            assert(!CharAnalyzer.isWhiteSpace('!'));
-            assert(!CharAnalyzer.isWhiteSpace('ă'));
+            assert.isFalse(CharAnalyzer.isWhiteSpace('a'));
+            assert.isFalse(CharAnalyzer.isWhiteSpace('!'));
+            assert.isFalse(CharAnalyzer.isWhiteSpace('ă'));
         });
     });
     describe('Unit: isPuntuaction', () => {
         it('check real puntuaction', () => {
-            assert(CharAnalyzer.isPunctuation('.'));
+            assert.isTrue(CharAnalyzer.isPunctuation('.'));
         });
         it('check fake puntuaction', () => {
-            assert(!CharAnalyzer.isPunctuation('a'));
-            assert(!CharAnalyzer.isPunctuation(' '));
+            assert.isFalse(CharAnalyzer.isPunctuation('a'));
+            assert.isFalse(CharAnalyzer.isPunctuation(' '));
         });
     });
     describe('Unit: isStopPunctuation', () => {
         it('check real puntuaction', () => {
-            assert(CharAnalyzer.isPunctuation('!'));
-            assert(CharAnalyzer.isStopPunctuation('!'));
+            assert.isTrue(CharAnalyzer.isPunctuation('!'));
+            assert.isTrue(CharAnalyzer.isStopPunctuation('!'));
         });
         it('check fake puntuaction', () => {
-            assert(CharAnalyzer.isPunctuation(','));
-            assert(!CharAnalyzer.isStopPunctuation(','));
-            assert(!CharAnalyzer.isStopPunctuation(' '));
-            assert(!CharAnalyzer.isStopPunctuation('a'));
+            assert.isTrue(CharAnalyzer.isPunctuation(','));
+            assert.isFalse(CharAnalyzer.isStopPunctuation(','));
+            assert.isFalse(CharAnalyzer.isStopPunctuation(' '));
+            assert.isFalse(CharAnalyzer.isStopPunctuation('a'));
         });
     });
     describe('Unit: isDiacritic', () => {
         it('check real diacritic', () => {
-            assert(CharAnalyzer.isDiacritic('ă'));
-            assert(CharAnalyzer.isDiacritic('ă'[1]));
+            assert.isTrue(CharAnalyzer.isDiacritic('ă'));
+            assert.isTrue(CharAnalyzer.isDiacritic('ă'[1]));
         });
         it('check fake diacritic', () => {
-            assert(!CharAnalyzer.isDiacritic('a'));
-            assert(!CharAnalyzer.isDiacritic(','));
-            assert(!CharAnalyzer.isDiacritic(' '));
+            assert.isFalse(CharAnalyzer.isDiacritic('a'));
+            assert.isFalse(CharAnalyzer.isDiacritic(','));
+            assert.isFalse(CharAnalyzer.isDiacritic(' '));
         });
     });
 });


### PR DESCRIPTION
`assert()` was used only with one argument, valid use is with two (assert(assertion, message)).
Because it was ugly, I changed it with assert.isTrue.